### PR TITLE
Added draft schedule and times (Work In Progress)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,10 +7,10 @@ import Tickets from "./components/Tickets";
 import CodeOfConduct from "./components/CodeOfConduct";
 import About from "./components/About";
 import Venue from "./components/Venue";
-import Team from "./components/Team";
 import Footer from "./components/Footer";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { fab } from "@fortawesome/free-brands-svg-icons";
+import { Schedule } from "./components/Schedule";
 
 library.add(fab);
 
@@ -18,9 +18,11 @@ function App() {
   return (
     <Router>
       <Switch>
-        <Route path="/" exact component={Home} />
-        <Route path="/speakers" component={Speakers} />
-        <Route path="/coc" component={CodeOfConduct} />
+        <Route exact path="/" component={Home} />
+        <Route exact path="/speakers" component={Speakers} />
+        <Route exact path="/coc" component={CodeOfConduct} />
+        <Route exact path="/schedule" component={Schedule} />
+        <Route component={() => <h4>Not Found</h4>} />
       </Switch>
     </Router>
   );
@@ -30,7 +32,7 @@ function Home() {
     <Fragment>
       <Info />
       <About />
-      <Venue /> 
+      <Venue />
       <Tickets />
       <Partners />
       {/*<Team />*/}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -70,6 +70,17 @@ function Header() {
                       <li className="nav-item">
                         <NavLink
                           smooth
+                          activeClassName={"active"}
+                          style={styles}
+                          to="/schedule"
+                        >
+                          Schedule
+                        </NavLink>
+                      </li>
+                      
+                      <li className="nav-item">
+                        <NavLink
+                          smooth
                           style={styles}
                           activeClassName={"active"}
                           to="/#about"

--- a/src/components/Schedule.js
+++ b/src/components/Schedule.js
@@ -59,12 +59,6 @@ function ScheduleItem({ schedule, id }) {
                   />
                   <br />
                   <br />
-                  <a href={schedule.githubLink} title="github">
-                    <FaGithubSquare size={20} />
-                  </a>
-                  <a href="https://twitter.com/Olivierjmm?s=17" title="twitter">
-                    <FaTwitterSquare size={20} />
-                  </a>
                 </div>
                 <div className="col-md-8 text-center">
                     <h2>{schedule.speaker}</h2>
@@ -76,6 +70,12 @@ function ScheduleItem({ schedule, id }) {
                   <span>60mins</span>
                 </div>
               </a>
+              <a href={schedule.githubLink} title="github">
+                    <FaGithubSquare size={20} />
+                  </a>
+                  <a href="https://twitter.com/Olivierjmm?s=17" title="twitter">
+                    <FaTwitterSquare size={20} />
+                  </a>
             </div>
           </div>
           <div
@@ -86,6 +86,7 @@ function ScheduleItem({ schedule, id }) {
             <div className="card-footer text-secondry">
               {schedule.description}
             </div>
+            
           </div>
         </div>
         <br />

--- a/src/components/Schedule.js
+++ b/src/components/Schedule.js
@@ -12,19 +12,24 @@ export class Schedule extends Component {
     return (
       <div>
         <Info />
+        <br />
         <Fragment>
-          <h1>{day1.day}</h1>
-          {day1.schedule.map(schedule => (
-            <ScheduleItem schedule={schedule} id={schedule.id} />
-          ))}
+          <div className="container">
+            <h3>{day1.day}</h3>
+            {day1.schedule.map(schedule => (
+              <ScheduleItem schedule={schedule} id={schedule.id} />
+            ))}
+          </div>
         </Fragment>
         <br />
         <br />
         <Fragment>
-          <h3>{day2.day}</h3>
-          {day2.schedule.map(_schedule => (
-            <ScheduleItem schedule={_schedule} id={_schedule.id} />
-          ))}
+          <div className="container">
+            <h3>{day2.day}</h3>
+            {day2.schedule.map(_schedule => (
+              <ScheduleItem schedule={_schedule} id={_schedule.id} />
+            ))}
+          </div>
         </Fragment>
         <Footer />
       </div>
@@ -34,42 +39,44 @@ export class Schedule extends Component {
 
 function ScheduleItem({ schedule, id }) {
   return (
-    <div className="container card border-primary">
-      <div id="accordion" key={id}>
-        <div className="container">
-          <div className="card-body border-primary">
-            <a
-              className="row card-link text-decoraton-none"
-              href={"#collapseOne" + id}
-              data-toggle="collapse"
-            >
-              <div className="col-md-1">
-                <img
-                  src={schedule.image}
-                  className="rounded-circle"
-                  width={80}
-                  height={80}
-                  alt="keynote speaker"
-                />
-                <br />
-                <br />
-                <a href={schedule.githubLink} title="github">
-                  <FaGithubSquare size={20} />
-                </a>
-                <a href="https://twitter.com/Olivierjmm?s=17" title="twitter">
-                  <FaTwitterSquare size={20} />
-                </a>
-              </div>
-              <div className="col-md-8 text-center">
-                  <h2>{schedule.speaker}</h2>
-                  <p>{schedule.topic}</p>
-              </div>
-              <div className="col-md-2 text-right">
-                <span>{schedule.time}</span> 
+    <div className="container">
+      <div className="card border-primary">
+        <div id="accordion" key={id}>
+          <div className="container">
+            <div className="card-body border-primary">
+              <a
+                className="row card-link text-decoraton-none"
+                href={"#collapseOne" + id}
+                data-toggle="collapse"
+              >
+                <div className="col-md-1">
+                  <img
+                    src={schedule.image}
+                    className="rounded-circle"
+                    width={80}
+                    height={80}
+                    alt="keynote speaker"
+                  />
                   <br />
-                <span>60mins</span>
-              </div>
-            </a>
+                  <br />
+                  <a href={schedule.githubLink} title="github">
+                    <FaGithubSquare size={20} />
+                  </a>
+                  <a href="https://twitter.com/Olivierjmm?s=17" title="twitter">
+                    <FaTwitterSquare size={20} />
+                  </a>
+                </div>
+                <div className="col-md-8 text-center">
+                    <h2>{schedule.speaker}</h2>
+                    <p>{schedule.topic}</p>
+                </div>
+                <div className="col-md-2 text-right">
+                  <span>{schedule.time}</span> 
+                    <br />
+                  <span>60mins</span>
+                </div>
+              </a>
+            </div>
           </div>
           <div
             id={"collapseOne" + id}

--- a/src/components/Schedule.js
+++ b/src/components/Schedule.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from "react";
 import { FaTwitterSquare, FaGithubSquare } from "react-icons/fa";
 import scheduleData from "../data/schedule.json";
-import Header from "./Header.js";
+import Info from "./Info";
 import Footer from "./Footer.js";
 
 
@@ -10,8 +10,8 @@ export class Schedule extends Component {
     // honestly this isn't the best solution, If it can be optimized further give it a go
     const [day1, day2] = scheduleData.schedule;
     return (
-      <div className="container">
-        <Header />
+      <div>
+        <Info />
         <Fragment>
           <h1>{day1.day}</h1>
           {day1.schedule.map(schedule => (
@@ -34,53 +34,55 @@ export class Schedule extends Component {
 
 function ScheduleItem({ schedule, id }) {
   return (
-    <div id="accordion" key={id}>
-      <div className="container">
-        <div className="card-body border-primary">
-          <a
-            className="row card-link text-decoraton-none"
-            href={"#collapseOne" + id}
-            data-toggle="collapse"
-          >
-            <div className="col-md-1">
-              <img
-                src={schedule.image}
-                className="rounded-circle"
-                width={80}
-                height={80}
-                alt="keynote speaker"
-              />
-              <br />
-              <br />
-              <a href={schedule.githubLink} title="github">
-                <FaGithubSquare size={20} />
-              </a>
-              <a href="https://twitter.com/Olivierjmm?s=17" title="twitter">
-                <FaTwitterSquare size={20} />
-              </a>
-            </div>
-            <div className="col-md-8 text-center">
-                <h2>{schedule.speaker}</h2>
-                <p>{schedule.topic}</p>
-            </div>
-            <div className="col-md-2 text-right">
-              <span>{schedule.time}</span> 
+    <div className="container card border-primary">
+      <div id="accordion" key={id}>
+        <div className="container">
+          <div className="card-body border-primary">
+            <a
+              className="row card-link text-decoraton-none"
+              href={"#collapseOne" + id}
+              data-toggle="collapse"
+            >
+              <div className="col-md-1">
+                <img
+                  src={schedule.image}
+                  className="rounded-circle"
+                  width={80}
+                  height={80}
+                  alt="keynote speaker"
+                />
                 <br />
-              <span>60mins</span>
+                <br />
+                <a href={schedule.githubLink} title="github">
+                  <FaGithubSquare size={20} />
+                </a>
+                <a href="https://twitter.com/Olivierjmm?s=17" title="twitter">
+                  <FaTwitterSquare size={20} />
+                </a>
+              </div>
+              <div className="col-md-8 text-center">
+                  <h2>{schedule.speaker}</h2>
+                  <p>{schedule.topic}</p>
+              </div>
+              <div className="col-md-2 text-right">
+                <span>{schedule.time}</span> 
+                  <br />
+                <span>60mins</span>
+              </div>
+            </a>
+          </div>
+          <div
+            id={"collapseOne" + id}
+            className="collapse"
+            data-parent="#accordion"
+          >
+            <div className="card-footer text-secondry">
+              {schedule.description}
             </div>
-          </a>
-        </div>
-        <div
-          id={"collapseOne" + id}
-          className="collapse"
-          data-parent="#accordion"
-        >
-          <div className="card-footer text-secondry">
-            {schedule.description}
           </div>
         </div>
+        <br />
       </div>
-      <br />
     </div>
   );
 }

--- a/src/components/Schedule.js
+++ b/src/components/Schedule.js
@@ -10,7 +10,7 @@ export class Schedule extends Component {
     // honestly this isn't the best solution, If it can be optimized further give it a go
     const [day1, day2] = scheduleData.schedule;
     return (
-      <div>
+      <div className="masthead">
         <Info />
         <br />
         <Fragment>
@@ -90,6 +90,7 @@ function ScheduleItem({ schedule, id }) {
         </div>
         <br />
       </div>
+      <br />
     </div>
   );
 }

--- a/src/components/Schedule.js
+++ b/src/components/Schedule.js
@@ -1,0 +1,86 @@
+import React, { Component, Fragment } from "react";
+import { FaTwitterSquare, FaGithubSquare } from "react-icons/fa";
+import scheduleData from "../data/schedule.json";
+import Header from "./Header.js";
+import Footer from "./Footer.js";
+
+
+export class Schedule extends Component {
+  render() {
+    // honestly this isn't the best solution, If it can be optimized further give it a go
+    const [day1, day2] = scheduleData.schedule;
+    return (
+      <div className="container">
+        <Header />
+        <Fragment>
+          <h1>{day1.day}</h1>
+          {day1.schedule.map(schedule => (
+            <ScheduleItem schedule={schedule} id={schedule.id} />
+          ))}
+        </Fragment>
+        <br />
+        <br />
+        <Fragment>
+          <h3>{day2.day}</h3>
+          {day2.schedule.map(_schedule => (
+            <ScheduleItem schedule={_schedule} id={_schedule.id} />
+          ))}
+        </Fragment>
+        <Footer />
+      </div>
+    );
+  }
+}
+
+function ScheduleItem({ schedule, id }) {
+  return (
+    <div id="accordion" key={id}>
+      <div className="container">
+        <div className="card-body border-primary">
+          <a
+            className="row card-link text-decoraton-none"
+            href={"#collapseOne" + id}
+            data-toggle="collapse"
+          >
+            <div className="col-md-1">
+              <img
+                src={schedule.image}
+                className="rounded-circle"
+                width={80}
+                height={80}
+                alt="keynote speaker"
+              />
+              <br />
+              <br />
+              <a href={schedule.githubLink} title="github">
+                <FaGithubSquare size={20} />
+              </a>
+              <a href="https://twitter.com/Olivierjmm?s=17" title="twitter">
+                <FaTwitterSquare size={20} />
+              </a>
+            </div>
+            <div className="col-md-8 text-center">
+                <h2>{schedule.speaker}</h2>
+                <p>{schedule.topic}</p>
+            </div>
+            <div className="col-md-2 text-right">
+              <span>{schedule.time}</span> 
+                <br />
+              <span>60mins</span>
+            </div>
+          </a>
+        </div>
+        <div
+          id={"collapseOne" + id}
+          className="collapse"
+          data-parent="#accordion"
+        >
+          <div className="card-footer text-secondry">
+            {schedule.description}
+          </div>
+        </div>
+      </div>
+      <br />
+    </div>
+  );
+}

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -1,0 +1,144 @@
+{
+    "schedule": [
+      {
+        "day": "Day One",
+        "schedule": [
+          {
+            "id": 1,
+            "time": "09:30am",
+            "activity": "Opening Keynote(S)",
+            "speaker": "Akintunde Sultan/Sponsor",
+            "topic": "Developers in Africa, Beginning to Intermediate",
+            "image": "/img/speakers/corbus.jpg",
+            "description": "Here is the topic description",
+            "twitterLink":"",
+            "githubLink":""
+          },
+          {
+            "id": 2,
+            "time": "10:30am",
+            "activity": "Topic",
+            "speaker": "Dennis Mubamba",
+            "topic": "Actors, Systems and Asynchronous Software Development",
+            "image": "/img/speakers/dennis.jpg",
+            "description": "Here is the topic description",
+            "twitterLink":"",
+            "githubLink":""
+          },
+          {
+            "id": 3,
+            "time": "11:00am",
+            "activity": "Workshop",
+            "speaker": "Mwaaba Mugala",
+            "topic": "The Game Industry - It's Time For Africa",
+            "image": "/img/speakers/sekayi.jpg",
+            "description": "Here is the topic description",
+            "twitterLink":"",
+            "githubLink":""
+          },
+          {
+            "id": 4,
+            "time": "12:00pm",
+            "activity": "Topic",
+            "speaker": "Rahul Sharma",
+            "topic": "Know it Better, Facilitate it Better",
+            "image": "/img/speakers/sekayi.jpg",
+            "description": "Here is the topic description",
+            "twitterLink":"",
+            "githubLink":""
+          },
+          {
+            "id": 5,
+            "time": "1:00pm",
+            "activity": "Lunch",
+            "speaker": "",
+            "topic": "Lunch",
+            "image": "/img/speakers/sekayi.jpg",
+            "description": "Here is the topic description",
+            "twitterLink":"",
+            "githubLink":""
+          },
+          {
+            "id": 6,
+            "time": "2:10pm",
+            "activity": "Interactive Exercise",
+            "speaker": "Ngosa Chungu",
+            "topic": "",
+            "image": "/img/speakers/sekayi.jpg",
+            "description": "Interactive Exercise",
+            "twitterLink":"",
+            "githubLink":""
+          },
+          {
+            "id": 7,
+            "time": "2:30pm",
+            "activity": "Interactive Topic",
+            "speaker": "Chinedu Koggu",
+            "topic": "Innovative Product Development from Concept to Launch",
+            "image": "/img/speakers/sekayi.jpg",
+            "description": "Here is the topic description",
+            "twitterLink":"",
+            "githubLink":""
+          },
+          {
+            "id": 8,
+            "time": "3:00pm",
+            "activity": "Topic",
+            "speaker": "Shakerrie Allmond",
+            "topic": "Impact of Helth Technology",
+            "image": "/img/speakers/sekayi.jpg",
+            "description": "Here is the topic description",
+            "twitterLink":"",
+            "githubLink":""
+          },
+          {
+            "id": 9,
+            "time": "3:30pm",
+            "activity": "Topic",
+            "speaker": "Olivier Mani",
+            "topic": "Modern PaaS on Azure",
+            "image": "/img/speakers/sekayi.jpg",
+            "description": "Here is the topic description",
+            "twitterLink":"https://twitter.com/Olivierjmm?s=17",
+            "githubLink":"https://github.com/OlivierJM"
+          },
+          {
+            "id": 10,
+            "time": "3:00pm",
+            "activity": "Closing Keynote",
+            "speaker": "Sponsor",
+            "topic": "Closing Keynote",
+            "image": "/img/speakers/sekayi.jpg",
+            "description": "Here is the topic description",
+            "twitterLink":"",
+            "githubLink":""
+          }
+        ]
+      },
+      {
+        "day": "Day Two",
+        "schedule": [
+          {
+            "id": 20,
+            "time": "09:30am",
+            "activity": "Opening Keynote(S)",
+            "speaker": "Sponsor",
+            "topic": "",
+            "image": "/img/speakers/dennis.jpg",
+            "description": "Here is the topic description",
+            "shortDescription":"Here is the short summarised topic description"
+          },
+          {
+            "id": 21,
+            "time": "10:30am",
+            "activity": "Topic",
+            "speaker": "Twaambo Hamuceenje",
+            "topic": "Building a Zambian Tech Company and Staying Sane",
+            "image": "/img/speakers/sekayi.jpg",
+            "description": "Here is the topic description",
+            "shortDescription":"Here is the short summarised topic description"
+          }
+        ]
+      }
+    ]
+  }

--- a/src/data/speakers.js
+++ b/src/data/speakers.js
@@ -1,0 +1,68 @@
+export const speakers = [
+    {
+      id: 1,
+      name: "Cobus Bernard ",
+      image: "/img/speakers/corbus.jpg",
+      company: "Senior Technical Evangelist -AWS Sub-Saharan Africa",
+      talk: "Modern App Development in the Cloud, Why Service Meshes?"
+    },
+    {
+      id: 2,
+      name: "Rahul Sharma",
+      image: "/img/speakers/rahul.jpg",
+      company: "Agile Coach at Think Agile",
+      talk: "Know it better, to facilitate it better"
+    },
+    {
+      id: 3,
+      name: " Dennis Mubamba",
+      image: "/img/speakers/dennis.jpg",
+      company: "Senior Software Engineer - Mika Express",
+      talk: "Actors systems and Asynchronous Software Development"
+    },
+    {
+      id: 4,
+      name: "Twaambo Haamucenje",
+      image: "/img/speakers/twaambo.jpg",
+      company: "CTO - Mvesesani Media",
+      talk: "Building a Zambian Company and Staying Sane"
+    },
+    {
+      id: 5,
+      name: "Sekayi Fundafunda Lungu",
+      image: "/img/speakers/sekayi.jpg",
+      company: "Campus Innovation Lead - BongoHive",
+      talk:
+        "Creativity for Technology: An interactive session on finding your niche"
+    },
+  
+    {
+      id: 6,
+      name: "Mwaamba Alec Mugala",
+      image: "/img/speakers/mwaamba.jpg",
+      company: "Director - EpicArts Studios",
+      talk: "The Game Industry - It is time For Africa"
+    },
+  
+    {
+      id: 7,
+      name: "Chinedu Koggu",
+      image: "img/speakers/chinedu.jpg",
+      company: "CTO - Probase Limited",
+      talk: "Innovative Product Development from Conception to launch"
+    },
+    {
+      id: 8,
+      name: "Shakerrie Almond",
+      image: "img/speakers/shakerrie.jpg",
+      company: "Chief Operations Officer - BroadPay",
+      talk: "TBD"
+    },
+    {
+      id: 9,
+      name: "Olivier JM Maniraho",
+      image: "img/speakers/olivier.jpg",
+      company: "Software Engineer - The ZIG",
+      talk: "People, Process and Tools with Azure DevOps"
+    }
+  ];


### PR DESCRIPTION
Tried to make it look like the suggested design as well #137 https://vuejs.london/schedule

Reference draft page from #144 

Still a couple of things to be worked on:
- schedule.json data needs to include day 2 data........ @OlivierJM link to the day 2 speaker and topic info.
- styling of the links. The Bootstrap hover effect default looks ugly.
- More details to put in the "description" dropdown. Probably going to come from the speakers I'm guessing.
-Use a lighter and "nicer" font on the schedule.

I'll continue working on this still but anyone please do feel free to chip in as always! 